### PR TITLE
Actualiza timestamp de inicio de sesión

### DIFF
--- a/src/main/java/com/mycompany/fixya/Autenticacion.java
+++ b/src/main/java/com/mycompany/fixya/Autenticacion.java
@@ -22,6 +22,7 @@ public class Autenticacion {
     public Usuario iniciarSesion(String nombreUsuario, String contrasena) {
         Usuario usuario = usuarioDAO.buscarPorNombreUsuario(nombreUsuario);
         if (usuario != null && BCrypt.checkpw(contrasena, usuario.getContrasenaHash())) {
+            usuarioDAO.actualizarUltimoLogin(nombreUsuario);
             return usuario;
         }
         return null;

--- a/src/main/java/com/mycompany/fixya/UsuarioDAO.java
+++ b/src/main/java/com/mycompany/fixya/UsuarioDAO.java
@@ -51,4 +51,17 @@ public class UsuarioDAO {
     public boolean existeNombreUsuario(String nombreUsuario) {
         return buscarPorNombreUsuario(nombreUsuario) != null;
     }
+
+    public void actualizarUltimoLogin(String nombreUsuario) {
+        String sql = "UPDATE usuarios SET last_login = NOW() WHERE nombre_usuario = ?";
+        try (Connection conn = ConexionDB.obtenerConexion();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+            pstmt.setString(1, nombreUsuario);
+            pstmt.executeUpdate();
+
+        } catch (SQLException e) {
+            System.err.println("Error al actualizar last_login: " + e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
## Resumen
- actualiza la columna `last_login` cada vez que un usuario inicia sesión

## Testing
- `mvn -q test` *(falló: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6863f0e9b5fc832da6f57f689d67b065