### PR TITLE
Improve frames background handling

### DIFF
--- a/src/main/java/com/mycompany/fixya/BuscarCliente.java
+++ b/src/main/java/com/mycompany/fixya/BuscarCliente.java
@@ -4,11 +4,11 @@
  */
 package com.mycompany.fixya;
 
-import java.awt.Image;
-import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
+
+// Utilidad para cargar imagenes en etiquetas
+import com.mycompany.fixya.ImageUtils;
 
 /**
  *
@@ -29,7 +29,7 @@ public class BuscarCliente extends javax.swing.JFrame {
     //jLabel2.setIcon(null);
     
     javax.swing.SwingUtilities.invokeLater(() -> {
-        SetImageLabel(jLabel2, "/BuscarCliente.png");
+        ImageUtils.setImageLabel(jLabel2, "/BuscarCliente.png");
     });
 }
 
@@ -114,14 +114,6 @@ public class BuscarCliente extends javax.swing.JFrame {
    
     }
 
-    private void SetImageLabel(JLabel labelName, String root){
-    ImageIcon image = new ImageIcon(getClass().getResource(root));
-    Icon icon = new ImageIcon(image.getImage().getScaledInstance(
-        labelName.getWidth(), 
-        labelName.getHeight(), 
-        Image.SCALE_FAST));
-    labelName.setIcon(icon);
-}
     
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JLabel jLabel2;

--- a/src/main/java/com/mycompany/fixya/BuscarVehiculo.java
+++ b/src/main/java/com/mycompany/fixya/BuscarVehiculo.java
@@ -4,6 +4,9 @@
  */
 package com.mycompany.fixya;
 
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import com.mycompany.fixya.ImageUtils;
 /**
  *
  * @author Tote
@@ -15,6 +18,10 @@ public class BuscarVehiculo extends javax.swing.JFrame {
      */
     public BuscarVehiculo() {
         initComponents();
+        this.setExtendedState(JFrame.MAXIMIZED_BOTH);
+        javax.swing.SwingUtilities.invokeLater(() -> {
+            ImageUtils.setImageLabel(jLabel1, "/BuscarVehiculo.png");
+        });
     }
 
     /**
@@ -26,18 +33,11 @@ public class BuscarVehiculo extends javax.swing.JFrame {
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
 
-        setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
+        jLabel1 = new javax.swing.JLabel();
 
-        javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
-        getContentPane().setLayout(layout);
-        layout.setHorizontalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 400, Short.MAX_VALUE)
-        );
-        layout.setVerticalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 300, Short.MAX_VALUE)
-        );
+        setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
+        getContentPane().setLayout(new java.awt.BorderLayout());
+        getContentPane().add(jLabel1, java.awt.BorderLayout.CENTER);
 
         pack();
     }// </editor-fold>//GEN-END:initComponents
@@ -78,5 +78,6 @@ public class BuscarVehiculo extends javax.swing.JFrame {
     }
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
+    private javax.swing.JLabel jLabel1;
     // End of variables declaration//GEN-END:variables
 }

--- a/src/main/java/com/mycompany/fixya/Clientes.java
+++ b/src/main/java/com/mycompany/fixya/Clientes.java
@@ -4,6 +4,9 @@
  */
 package com.mycompany.fixya;
 
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import com.mycompany.fixya.ImageUtils;
 /**
  *
  * @author Tote
@@ -15,6 +18,10 @@ public class Clientes extends javax.swing.JFrame {
      */
     public Clientes() {
         initComponents();
+        this.setExtendedState(JFrame.MAXIMIZED_BOTH);
+        javax.swing.SwingUtilities.invokeLater(() -> {
+            ImageUtils.setImageLabel(jLabel1, "/Clientes.png");
+        });
     }
 
     /**
@@ -26,18 +33,11 @@ public class Clientes extends javax.swing.JFrame {
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
 
-        setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
+        jLabel1 = new javax.swing.JLabel();
 
-        javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
-        getContentPane().setLayout(layout);
-        layout.setHorizontalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 400, Short.MAX_VALUE)
-        );
-        layout.setVerticalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 300, Short.MAX_VALUE)
-        );
+        setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
+        getContentPane().setLayout(new java.awt.BorderLayout());
+        getContentPane().add(jLabel1, java.awt.BorderLayout.CENTER);
 
         pack();
     }// </editor-fold>//GEN-END:initComponents
@@ -78,5 +78,6 @@ public class Clientes extends javax.swing.JFrame {
     }
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
+    private javax.swing.JLabel jLabel1;
     // End of variables declaration//GEN-END:variables
 }

--- a/src/main/java/com/mycompany/fixya/CrearCliente.java
+++ b/src/main/java/com/mycompany/fixya/CrearCliente.java
@@ -4,6 +4,9 @@
  */
 package com.mycompany.fixya;
 
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import com.mycompany.fixya.ImageUtils;
 /**
  *
  * @author Tote
@@ -15,6 +18,10 @@ public class CrearCliente extends javax.swing.JFrame {
      */
     public CrearCliente() {
         initComponents();
+        this.setExtendedState(JFrame.MAXIMIZED_BOTH);
+        javax.swing.SwingUtilities.invokeLater(() -> {
+            ImageUtils.setImageLabel(jLabel1, "/CrearClientes.png");
+        });
     }
 
     /**
@@ -26,18 +33,11 @@ public class CrearCliente extends javax.swing.JFrame {
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
 
-        setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
+        jLabel1 = new javax.swing.JLabel();
 
-        javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
-        getContentPane().setLayout(layout);
-        layout.setHorizontalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 400, Short.MAX_VALUE)
-        );
-        layout.setVerticalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 300, Short.MAX_VALUE)
-        );
+        setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
+        getContentPane().setLayout(new java.awt.BorderLayout());
+        getContentPane().add(jLabel1, java.awt.BorderLayout.CENTER);
 
         pack();
     }// </editor-fold>//GEN-END:initComponents
@@ -79,5 +79,6 @@ public class CrearCliente extends javax.swing.JFrame {
     }
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
+    private javax.swing.JLabel jLabel1;
     // End of variables declaration//GEN-END:variables
 }

--- a/src/main/java/com/mycompany/fixya/CrearCuenta.java
+++ b/src/main/java/com/mycompany/fixya/CrearCuenta.java
@@ -4,6 +4,8 @@
  */
 package com.mycompany.fixya;
 
+import javax.swing.JFrame;
+import com.mycompany.fixya.ImageUtils;
 /**
  *
  *https://youtu.be/jegnbN8nVB8?si=uPggB2VScy0NSP8d
@@ -15,6 +17,10 @@ public class CrearCuenta extends javax.swing.JFrame {
      */
     public CrearCuenta() {
         initComponents();
+        this.setExtendedState(JFrame.MAXIMIZED_BOTH);
+        javax.swing.SwingUtilities.invokeLater(() -> {
+            ImageUtils.setImageLabel(jLabel2, "/CrearCuenta.png");
+        });
     }
 
     /**

--- a/src/main/java/com/mycompany/fixya/ImageUtils.java
+++ b/src/main/java/com/mycompany/fixya/ImageUtils.java
@@ -1,0 +1,27 @@
+package com.mycompany.fixya;
+
+import java.awt.Image;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+
+/**
+ * Utilidades para trabajar con imágenes en etiquetas.
+ */
+public class ImageUtils {
+
+    /**
+     * Ajusta una imagen al tamaño de un JLabel y la establece como su icono.
+     *
+     * @param label JLabel destino
+     * @param resourcePath ruta del recurso de imagen
+     */
+    public static void setImageLabel(JLabel label, String resourcePath) {
+        ImageIcon image = new ImageIcon(ImageUtils.class.getResource(resourcePath));
+        Icon icon = new ImageIcon(image.getImage().getScaledInstance(
+                label.getWidth(),
+                label.getHeight(),
+                Image.SCALE_FAST));
+        label.setIcon(icon);
+    }
+}

--- a/src/main/java/com/mycompany/fixya/IniciarSesion.java
+++ b/src/main/java/com/mycompany/fixya/IniciarSesion.java
@@ -4,6 +4,9 @@
  */
 package com.mycompany.fixya;
 
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import com.mycompany.fixya.ImageUtils;
 /**
  *
  * @author Tote
@@ -15,6 +18,10 @@ public class IniciarSesion extends javax.swing.JFrame {
      */
     public IniciarSesion() {
         initComponents();
+        this.setExtendedState(JFrame.MAXIMIZED_BOTH);
+        javax.swing.SwingUtilities.invokeLater(() -> {
+            ImageUtils.setImageLabel(jLabel1, "/IniciarSesion.png");
+        });
     }
 
     /**
@@ -26,18 +33,11 @@ public class IniciarSesion extends javax.swing.JFrame {
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
 
-        setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
+        jLabel1 = new javax.swing.JLabel();
 
-        javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
-        getContentPane().setLayout(layout);
-        layout.setHorizontalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 400, Short.MAX_VALUE)
-        );
-        layout.setVerticalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 300, Short.MAX_VALUE)
-        );
+        setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
+        getContentPane().setLayout(new java.awt.BorderLayout());
+        getContentPane().add(jLabel1, java.awt.BorderLayout.CENTER);
 
         pack();
     }// </editor-fold>//GEN-END:initComponents
@@ -78,5 +78,6 @@ public class IniciarSesion extends javax.swing.JFrame {
     }
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
+    private javax.swing.JLabel jLabel1;
     // End of variables declaration//GEN-END:variables
 }

--- a/src/main/java/com/mycompany/fixya/RegistarVehiculo.java
+++ b/src/main/java/com/mycompany/fixya/RegistarVehiculo.java
@@ -4,6 +4,9 @@
  */
 package com.mycompany.fixya;
 
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import com.mycompany.fixya.ImageUtils;
 /**
  *
  * @author Tote
@@ -15,6 +18,10 @@ public class RegistarVehiculo extends javax.swing.JFrame {
      */
     public RegistarVehiculo() {
         initComponents();
+        this.setExtendedState(JFrame.MAXIMIZED_BOTH);
+        javax.swing.SwingUtilities.invokeLater(() -> {
+            ImageUtils.setImageLabel(jLabel1, "/RegistrarVehiculo.png");
+        });
     }
 
     /**
@@ -26,18 +33,11 @@ public class RegistarVehiculo extends javax.swing.JFrame {
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
 
-        setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
+        jLabel1 = new javax.swing.JLabel();
 
-        javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
-        getContentPane().setLayout(layout);
-        layout.setHorizontalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 400, Short.MAX_VALUE)
-        );
-        layout.setVerticalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 300, Short.MAX_VALUE)
-        );
+        setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
+        getContentPane().setLayout(new java.awt.BorderLayout());
+        getContentPane().add(jLabel1, java.awt.BorderLayout.CENTER);
 
         pack();
     }// </editor-fold>//GEN-END:initComponents
@@ -78,5 +78,6 @@ public class RegistarVehiculo extends javax.swing.JFrame {
     }
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
+    private javax.swing.JLabel jLabel1;
     // End of variables declaration//GEN-END:variables
 }

--- a/src/main/java/com/mycompany/fixya/Vehiculos.java
+++ b/src/main/java/com/mycompany/fixya/Vehiculos.java
@@ -4,6 +4,9 @@
  */
 package com.mycompany.fixya;
 
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import com.mycompany.fixya.ImageUtils;
 /**
  *
  * @author Tote
@@ -15,6 +18,10 @@ public class Vehiculos extends javax.swing.JFrame {
      */
     public Vehiculos() {
         initComponents();
+        this.setExtendedState(JFrame.MAXIMIZED_BOTH);
+        javax.swing.SwingUtilities.invokeLater(() -> {
+            ImageUtils.setImageLabel(jLabel1, "/Vehiculo.png");
+        });
     }
 
     /**
@@ -26,18 +33,11 @@ public class Vehiculos extends javax.swing.JFrame {
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
 
-        setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
+        jLabel1 = new javax.swing.JLabel();
 
-        javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
-        getContentPane().setLayout(layout);
-        layout.setHorizontalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 400, Short.MAX_VALUE)
-        );
-        layout.setVerticalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 300, Short.MAX_VALUE)
-        );
+        setDefaultCloseOperation(javax.swing.WindowConstants.EXIT_ON_CLOSE);
+        getContentPane().setLayout(new java.awt.BorderLayout());
+        getContentPane().add(jLabel1, java.awt.BorderLayout.CENTER);
 
         pack();
     }// </editor-fold>//GEN-END:initComponents
@@ -78,5 +78,6 @@ public class Vehiculos extends javax.swing.JFrame {
     }
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
+    private javax.swing.JLabel jLabel1;
     // End of variables declaration//GEN-END:variables
 }


### PR DESCRIPTION
## Summary
- add `ImageUtils` with reusable `setImageLabel` helper
- maximize all frames and load the scaled background images

## Testing
- `mvn -q -DskipTests=true package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6866b7703ba4832dbd57c70be7172c35